### PR TITLE
Doc: PyPI link to RTD

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ long_description_content_type = text/markdown
 url = https://github.com/bwheelz36/ParticlePhaseSpace
 project_urls =
     Bug Tracker = https://github.com/bwheelz36/ParticlePhaseSpace/issues
+    Documentation = https://bwheelz36.github.io/ParticlePhaseSpace
 classifiers =
     Programming Language :: Python :: 3
     Operating System :: OS Independent


### PR DESCRIPTION
There is a cool feature to cross-link the user-facing documentation (and other URLs) in PyPI, too. This saves users a hop over the source repo and might be useful for completion.