### PR TITLE
add a fix for negative particles

### DIFF
--- a/ParticlePhaseSpace/DataLoaders.py
+++ b/ParticlePhaseSpace/DataLoaders.py
@@ -477,6 +477,9 @@ class Load_IAEA(_DataLoadersBase):
         :param varian_types:
         :return:
         """
+        if np.min(varian_types) < 0:
+            warnings.warn("negative particle types detected in phase space. I have no idea what this means: converting to postiive and continuing")
+            varian_types = np.abs(varian_types)
         pdg_types = np.zeros(varian_types.shape, dtype=np.int32)
         for type in np.unique(varian_types):
             if not type in [1, 2, 3, 4, 5]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "particlephasespace"
-version = "0.7.2"
+version = "0.7.3"
 description = "Import, analysis, and export of particle phase space data"
 authors = ["Brendan <bwheelz360@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Some data on the IAEA website seems to contain negative value for particle type. 
that is not a valid part of the IAEA specification, so in this PR I simply force them to positive with a warning.
fixes #184.